### PR TITLE
Fix extra space in autopb.hosts.mk output filename

### DIFF
--- a/autopb/autopb
+++ b/autopb/autopb
@@ -37,7 +37,7 @@ getpbhosts();
 
 # process hosts.mk template
 my %vars = ( pbhosts => \%PBHOSTS, site => $SITE );
-$tt->process( \*DATA, \%vars, "$HOME/tmp/autopb.hosts.mk " )
+$tt->process( \*DATA, \%vars, "$HOME/tmp/autopb.hosts.mk" )
   || die
   "CRIT: Template hosts.mk.tt could not be processed to tmp/autopb.hosts.mk.\n";
 


### PR DESCRIPTION
Removed a trailing space in the output path: "$HOME/tmp/autopb.hosts.mk ".

The extra space resulted in generating a file with an incorrect filename, causing mismatches during comparison, copying, and unlink operations.

Now the file is correctly written to "$HOME/tmp/autopb.hosts.mk".